### PR TITLE
feat: add double tap privacy toggle to widget

### DIFF
--- a/app/src/main/res/layout/widget_portfolio.xml
+++ b/app/src/main/res/layout/widget_portfolio.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"


### PR DESCRIPTION
## Summary
- add double-tap gesture on widget to hide/show values
- store last fetched totals and display "*****" when hidden
- add widget root id to capture taps

## Testing
- `./gradlew test` *(fails: Define BITVAVO_API_KEY/SECRET in bitvavo.properties)*

------
https://chatgpt.com/codex/tasks/task_b_68a102d763988324889358a05a0881f5