### PR TITLE
Define TAG constant for PortfolioWidgetProvider

### DIFF
--- a/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
@@ -35,6 +35,7 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
         .build()
 
     companion object {
+        private const val TAG = "PortfolioWidgetProvider"
         private const val ACTION_UPDATE = "com.spymag.PORTFOLIO_UPDATE"
         private const val ACTION_TAP = "com.spymag.PORTFOLIO_TAP"
         private const val UNIQUE_WORK_NAME = "PortfolioUpdateWork"


### PR DESCRIPTION
## Summary
- Add missing TAG constant to PortfolioWidgetProvider companion object

## Testing
- `./gradlew test` *(fails: Define BITVAVO_API_KEY/SECRET in bitvavo.properties)*

------
https://chatgpt.com/codex/tasks/task_b_68a10761388c8324b61a0ca634f39025