### PR TITLE
Add visibility toggle to widget

### DIFF
--- a/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
@@ -15,8 +15,6 @@ import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
 
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import android.widget.RemoteViews
 import okhttp3.OkHttpClient
@@ -39,7 +37,7 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
     companion object {
         private const val TAG = "PortfolioWidgetProvider"
         private const val ACTION_UPDATE = "com.spymag.PORTFOLIO_UPDATE"
-        private const val ACTION_TAP = "com.spymag.PORTFOLIO_TAP"
+        private const val ACTION_TOGGLE = "com.spymag.PORTFOLIO_TOGGLE"
         private const val UNIQUE_WORK_NAME = "PortfolioUpdateWork"
         private const val PREFS_NAME = "portfolio_widget_prefs"
         private const val PREF_HIDE_VALUES = "hide_values"
@@ -48,11 +46,6 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
         private const val PREF_BITVAVO_TIME = "bitvavo_time"
         private const val PREF_TRADING212_TIME = "trading212_time"
         private const val UPDATE_INTERVAL = 15 * 60 * 1000L
-        private const val DOUBLE_TAP_TIMEOUT = 400L
-        private var lastClickTime = 0L
-        private val handler = Handler(Looper.getMainLooper())
-        private var singleTapRunnable: Runnable? = null
-
         fun pendingIntent(context: Context): PendingIntent {
             val intent = Intent(context, PortfolioWidgetProvider::class.java).apply {
                 action = ACTION_UPDATE
@@ -65,13 +58,25 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
             )
         }
 
-        fun tapPendingIntent(context: Context): PendingIntent {
+        fun updatePendingIntent(context: Context): PendingIntent {
             val intent = Intent(context, PortfolioWidgetProvider::class.java).apply {
-                action = ACTION_TAP
+                action = ACTION_UPDATE
             }
             return PendingIntent.getBroadcast(
                 context,
                 1,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        fun togglePendingIntent(context: Context): PendingIntent {
+            val intent = Intent(context, PortfolioWidgetProvider::class.java).apply {
+                action = ACTION_TOGGLE
+            }
+            return PendingIntent.getBroadcast(
+                context,
+                2,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
@@ -93,23 +98,11 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
         when (intent.action) {
-            ACTION_TAP -> {
-                val now = System.currentTimeMillis()
-                if (singleTapRunnable != null && now - lastClickTime < DOUBLE_TAP_TIMEOUT) {
-                    handler.removeCallbacks(singleTapRunnable!!)
-                    singleTapRunnable = null
-                    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-                    val hidden = prefs.getBoolean(PREF_HIDE_VALUES, false)
-                    prefs.edit().putBoolean(PREF_HIDE_VALUES, !hidden).apply()
-                    refreshWidgetFromPrefs(context)
-                } else {
-                    lastClickTime = now
-                    singleTapRunnable = Runnable {
-                        triggerUpdate(context)
-                        singleTapRunnable = null
-                    }
-                    handler.postDelayed(singleTapRunnable!!, DOUBLE_TAP_TIMEOUT)
-                }
+            ACTION_TOGGLE -> {
+                val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                val hidden = prefs.getBoolean(PREF_HIDE_VALUES, false)
+                prefs.edit().putBoolean(PREF_HIDE_VALUES, !hidden).apply()
+                refreshWidgetFromPrefs(context)
             }
             AppWidgetManager.ACTION_APPWIDGET_UPDATE, ACTION_UPDATE -> {
                 triggerUpdate(context)
@@ -178,15 +171,18 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
         for (appWidgetId in ids) {
             val rv = RemoteViews(context.packageName, R.layout.widget_portfolio)
             if (hidden) {
-                rv.setTextViewText(R.id.tvValue1, "*****")
-                rv.setTextViewText(R.id.tvValue2, "*****")
+                rv.setTextViewText(R.id.tvValue1, "Bitvavo total: ******")
+                rv.setTextViewText(R.id.tvValue2, "Trading212 total: ******")
+                rv.setImageViewResource(R.id.ivToggle, R.drawable.ic_visibility_off)
             } else {
                 val bitText = "Bitvavo total: $bitvavo (${formatTime(bitTime)})"
                 val tradingText = "Trading212 total: $trading (${formatTime(tradingTime)})"
                 rv.setTextViewText(R.id.tvValue1, bitText)
                 rv.setTextViewText(R.id.tvValue2, tradingText)
+                rv.setImageViewResource(R.id.ivToggle, R.drawable.ic_visibility)
             }
-            rv.setOnClickPendingIntent(R.id.widget_root, tapPendingIntent(context))
+            rv.setOnClickPendingIntent(R.id.ivToggle, togglePendingIntent(context))
+            rv.setOnClickPendingIntent(R.id.content_layout, updatePendingIntent(context))
             mgr.updateAppWidget(appWidgetId, rv)
         }
     }

--- a/app/src/main/res/drawable/ic_visibility.xml
+++ b/app/src/main/res/drawable/ic_visibility.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:pathData="M12,4C7,4 2.73,7 1,12c1.73,5 6,8 11,8s9.27,-3 11,-8c-1.73,-5 -6,-8 -11,-8z"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8a4,4 0 1,1 0,8a4,4 0 1,1 0,-8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_visibility_off.xml
+++ b/app/src/main/res/drawable/ic_visibility_off.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:pathData="M12,4C7,4 2.73,7 1,12c1.73,5 6,8 11,8s9.27,-3 11,-8c-1.73,-5 -6,-8 -11,-8z"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8a4,4 0 1,1 0,8a4,4 0 1,1 0,-8z"/>
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:pathData="M3,3L21,21"/>
+</vector>

--- a/app/src/main/res/layout/widget_portfolio.xml
+++ b/app/src/main/res/layout/widget_portfolio.xml
@@ -1,22 +1,43 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
-    android:layout_width="wrap_content"
+    android:layout_width="200dp"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:background="@android:color/white"
     android:padding="8dp">
 
-    <TextView
-        android:id="@+id/tvValue1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="—"
-        android:textSize="14sp"/>
+    <ImageView
+        android:id="@+id/ivToggle"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_visibility"
+        android:contentDescription="@string/toggle_visibility"
+        android:layout_marginEnd="8dp"/>
 
-    <TextView
-        android:id="@+id/tvValue2"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/content_layout"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="—"
-        android:textSize="14sp"/>
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvValue1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="—"
+            android:textSize="14sp"/>
+
+        <TextView
+            android:id="@+id/tvValue2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="—"
+            android:textSize="14sp"/>
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">PortfolioWidget</string>
+    <string name="toggle_visibility">Toggle visibility</string>
 </resources>


### PR DESCRIPTION
## Summary
- redraw eye icons with visible pupil for clearer show/hide toggle
- mask only portfolio values with asterisks while keeping labels
- set fixed widget width and ellipsize text to avoid size changes

## Testing
- `./gradlew test` *(fails: Define BITVAVO_API_KEY/SECRET in bitvavo.properties)*

------
https://chatgpt.com/codex/tasks/task_b_68a16e6785d4832487e85f4827e73fc5