### PR TITLE
Trigger update on widget installation

### DIFF
--- a/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
@@ -95,6 +95,15 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
         WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
     }
 
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        triggerUpdate(context)
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
         when (intent.action) {


### PR DESCRIPTION
## Summary
- Ensure newly added widgets refresh immediately by invoking `triggerUpdate` inside `onUpdate`

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1bb8587648324a84ebc6f2327c5d2