### PR TITLE
Expand toggle touch area

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Spymag
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# PortfolioWidget
+
+An Android home screen widget that displays combined portfolio values from Bitvavo and Trading212 accounts.
+
+## Setup
+
+1. Create a `bitvavo.properties` file in the project root with your Bitvavo API credentials:
+   ```properties
+   BITVAVO_API_KEY=your_api_key
+   BITVAVO_API_SECRET=your_api_secret
+   ```
+2. Create a `trading212.properties` file in the project root with your Trading212 API key:
+   ```properties
+   TRADING212_API_KEY=your_api_key
+   ```
+3. Build the project using:
+   ```bash
+   ./gradlew assembleDebug
+   ```
+
+## Testing
+
+Run the unit tests with:
+```bash
+./gradlew test
+```
+
+Tests require valid Bitvavo and Trading212 credentials as described above and will fail without them.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/app/src/main/res/layout/widget_portfolio.xml
+++ b/app/src/main/res/layout/widget_portfolio.xml
@@ -8,8 +8,9 @@
 
     <ImageView
         android:id="@+id/ivToggle"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:padding="10dp"
         android:src="@drawable/ic_visibility"
         android:contentDescription="@string/toggle_visibility"
         android:layout_marginEnd="8dp"


### PR DESCRIPTION
## Summary
- remove redundant background from toggle icon
- keep toggle icon at 20dp with 40dp transparent touch area
- add README with setup and testing instructions
- note Trading212 API key requirement and MIT licensing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68a1be2c431c8324beafbe43319d6784