### PR TITLE
Fix Android graphics driver warnings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
             </intent-filter>
         </activity> */
         -->
+        <meta-data android:name="com.google.android.graphics.driver.production.allow" android:value="true" />
+
         <receiver
             android:name=".PortfolioWidgetProvider"
             android:exported="true">


### PR DESCRIPTION
This change addresses verbose log messages related to the Android GraphicsEnvironment that appear on application startup.

The primary error, "App is not on the allowlist for updatable production driver," is resolved by adding a meta-data tag to the AndroidManifest.xml to explicitly allow the use of the production graphics driver.

It is presumed that this also resolves the related "Global.Settings values are invalid" message, which is a verbose log that likely stems from the same root cause.