### PR TITLE
feat: Display date and time in widget and fix update issue

### DIFF
--- a/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
@@ -91,18 +91,23 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
                 refreshWidgetFromPrefs(context)
             }
             AppWidgetManager.ACTION_APPWIDGET_UPDATE, ACTION_UPDATE -> {
-                triggerUpdate(context)
+                val pendingResult = goAsync()
+                triggerUpdate(context, pendingResult)
             }
         }
     }
 
-    private fun triggerUpdate(context: Context) {
+    private fun triggerUpdate(context: Context, pendingResult: PendingResult? = null) {
         scope.launch {
-            val summary = portfolioRepository.getPortfolioSummary()
-            Log.d(TAG, "Fetched Bitvavo total value: ${summary.bitvavoTotal}")
-            Log.d(TAG, "Fetched Trading212 total value: ${summary.trading212Total}")
+            try {
+                val summary = portfolioRepository.getPortfolioSummary()
+                Log.d(TAG, "Fetched Bitvavo total value: ${summary.bitvavoTotal}")
+                Log.d(TAG, "Fetched Trading212 total value: ${summary.trading212Total}")
 
-            updateWidgetTotal(context, summary.bitvavoTotal, summary.trading212Total)
+                updateWidgetTotal(context, summary.bitvavoTotal, summary.trading212Total)
+            } finally {
+                pendingResult?.finish()
+            }
         }
     }
 
@@ -139,8 +144,8 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
                 rv.setTextViewText(R.id.tvValue2, "Trading212 total: ******")
                 rv.setImageViewResource(R.id.ivToggle, R.drawable.ic_visibility_off)
             } else {
-                val bitText = "Bitvavo total: $bitvavo (${TimeFormatter.formatRelativeTime(bitTime)})"
-                val tradingText = "Trading212 total: $trading (${TimeFormatter.formatRelativeTime(tradingTime)})"
+                val bitText = "Bitvavo total: $bitvavo (${TimeFormatter.formatDateTime(bitTime)})"
+                val tradingText = "Trading212 total: $trading (${TimeFormatter.formatDateTime(tradingTime)})"
                 rv.setTextViewText(R.id.tvValue1, bitText)
                 rv.setTextViewText(R.id.tvValue2, tradingText)
                 rv.setImageViewResource(R.id.ivToggle, R.drawable.ic_visibility)

--- a/app/src/main/java/com/spymag/portfoliowidget/ui/TimeFormatter.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/ui/TimeFormatter.kt
@@ -1,8 +1,21 @@
 package com.spymag.portfoliowidget.ui
 
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 object TimeFormatter {
+
+    fun formatDateTime(timestamp: Long, timeZone: TimeZone = TimeZone.getDefault()): String {
+        if (timestamp == 0L) return "N/A"
+        val date = Date(timestamp)
+        val format = SimpleDateFormat("dd-MM HH:mm", Locale.getDefault()).apply {
+            this.timeZone = timeZone
+        }
+        return format.format(date)
+    }
 
     fun formatRelativeTime(timestamp: Long): String {
         if (timestamp == 0L) return "N/A"

--- a/app/src/test/java/com/spymag/portfoliowidget/ui/TimeFormatterTest.kt
+++ b/app/src/test/java/com/spymag/portfoliowidget/ui/TimeFormatterTest.kt
@@ -1,0 +1,22 @@
+package com.spymag.portfoliowidget.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.TimeZone
+
+class TimeFormatterTest {
+
+    @Test
+    fun `formatDateTime should format timestamp correctly with specific timezone`() {
+        // Given a specific timestamp and timezone
+        val timestamp = 1672531200000L // 2023-01-01 00:00:00 GMT
+        val gmtTimeZone = TimeZone.getTimeZone("GMT")
+
+        // When formatting the timestamp with the specific timezone
+        val formattedDate = TimeFormatter.formatDateTime(timestamp, gmtTimeZone)
+
+        // Then the output should be in the correct format for that timezone
+        val expectedDate = "01-01 00:00"
+        assertEquals(expectedDate, formattedDate)
+    }
+}


### PR DESCRIPTION
This change modifies the portfolio widget to display the date and time for each retrieved line, instead of the relative time. The time is displayed in the user's local timezone.

A new function `formatDateTime` has been added to the `TimeFormatter` object to format the timestamp. This function now accepts an optional `TimeZone` parameter, which defaults to the system's default timezone. The `PortfolioWidgetProvider` has been updated to use this new function.

A unit test has also been added to verify the correctness of the new formatting function. The test uses a fixed timezone (GMT) to ensure it is stable and not dependent on the environment.

Additionally, this change fixes a bug where the widget update process was being killed by the OS before it could complete. This was addressed by using `goAsync()` in the `onReceive` method of the `PortfolioWidgetProvider` to allow for longer-running background tasks.