### PR TITLE
Update widget when screen turns on or unlocks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="android.intent.action.SCREEN_ON" />
+                <action android:name="android.intent.action.USER_PRESENT" />
                 <!--<action android:name="com.spymag.PORTFOLIO_UPDATE" />-->
             </intent-filter>
             <meta-data

--- a/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
+++ b/app/src/main/java/com/spymag/portfoliowidget/PortfolioWidgetProvider.kt
@@ -111,6 +111,7 @@ class PortfolioWidgetProvider : AppWidgetProvider() {
                 prefs.edit().putBoolean(PREF_HIDE_VALUES, !hidden).apply()
                 refreshWidgetFromPrefs(context)
             }
+            Intent.ACTION_SCREEN_ON, Intent.ACTION_USER_PRESENT,
             AppWidgetManager.ACTION_APPWIDGET_UPDATE, ACTION_UPDATE -> {
                 triggerUpdate(context)
             }


### PR DESCRIPTION
## Summary
- Refresh widget when screen turns on or user unlocks the device
- Register broadcast receivers for screen-on and user-present events

## Testing
- `./gradlew test` *(fails: Define BITVAVO_API_KEY/SECRET in bitvavo.properties)*

------
https://chatgpt.com/codex/tasks/task_b_68a8c91a7f148324ababafbd81a0a491